### PR TITLE
Criacao da conexao comum a API

### DIFF
--- a/labeddit/src/services/api.js
+++ b/labeddit/src/services/api.js
@@ -1,0 +1,19 @@
+import axios from axios;
+
+const conection =  axios.create({
+
+    baseURL: 'https://us-central1-labenu-apis.cloudfunctions.net/labEddit/',
+    headers: { 'content-type' : 'application/json' }
+})
+
+export function Get(url){
+    return conection.get(url);
+}
+
+export function Post(url, data){
+    return conection.post(url, data);
+}
+
+export function Put(url, data){
+    return conection.put(url, data);
+}


### PR DESCRIPTION
Criacao da conexao comum a API.

Conexão que será usada por todas as páginas e componentes.

Elementos POST, GET e PUT exportados individualmente.
Basta importar em seu projeto o que for ser usado
ex:
Import { Get } from ../api